### PR TITLE
Fix pod install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "React Native Subnet Mask for IOS and Android",
   "license": "MIT",
   "main": "index.js",
+  "homepage": "https://github.com/kacgrzes/get-subnet-mask",
   "author": {
     "name": "Hamid reza Pour khosh safar",
     "email": "hrp_71@yahoo.com",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React Native Subnet Mask for IOS and Android",
   "license": "MIT",
   "main": "index.js",
-  "homepage": "https://github.com/kacgrzes/get-subnet-mask",
+  "homepage": "https://github.com/maxto024/get-subnet-mask",
   "author": {
     "name": "Hamid reza Pour khosh safar",
     "email": "hrp_71@yahoo.com",


### PR DESCRIPTION
On ios when i run `pod install` I get:

```
[!] The `react-native-custom-module` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | github_sources: Github repositories should end in `.git`.
    - WARN  | description: The description is equal to the summary.
```

homepage is read from package.json and it was missing there. This small PR fixes that